### PR TITLE
fix: ECS cluster name parameter

### DIFF
--- a/ecs.tf
+++ b/ecs.tf
@@ -12,7 +12,8 @@ locals {
 
   cluster    = {
     id                   = var.cluster_id
-    name                 = var.cluster_id
+    name                 = var.cluster_cluster_name
+    cluster_name         = var.cluster_cluster_name
     service_namespace_id = var.cluster_service_namespace_id
     region               = var.cluster_region
     vpc_id               = var.cluster_vpc_id


### PR DESCRIPTION
It appears that we accidentally passed the cluster-id as the
cluster-name.  More curious is that the default code passes cluster name
as cluster['cluster_name'].  To that end we have updated the map to
support name and cluster_name to both aquire the correct value.