### PR TITLE
fix: pin AWS provider version to ~> 5.0.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = "~> 0.12"
   required_providers {
-    aws = ">= 4.0"
+    aws = "~> 5.0.0"
   }
 }


### PR DESCRIPTION
At present, we do not have a defined upper limit for the AWS provider version, which is leading to compatibility issues with the existing Terraform version.

**Error:**

> Error: unsupported Terraform version: 0.12.31. This version of Terraform is not supported with pre-release version of the Terraform AWS Provider but will be supported at GA. See https://developer.hashicorp.com/terraform/language/providers/requirements#v0-12-compatible-provider-requirements for details of how to specify an exact provider version to use