### PR TITLE
feat(DPLAT-378): add option to remove Route53 A record from state before destroy

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -113,6 +113,9 @@ inputs:
   destroy:
     description: 'Perform Terraform Destroy'
     default: false
+  remove_r53_record_from_state:
+    description: 'Remove main Route53 A record from state before destroy'
+    default: false
   debug:
     description: 'enable debugging'
     default: false

--- a/route53.tf
+++ b/route53.tf
@@ -8,4 +8,8 @@ resource "aws_route53_record" "default" {
     zone_id                 = module.ecs.lb["zone_id"]
     evaluate_target_health  = true
   }
+
+  lifecycle {
+    ignore_changes = all
+  }
 }


### PR DESCRIPTION
## Summary
This PR adds a new `remove_r53_record_from_state` option to the GitHub Action inputs that allows removing the Route53 A record from Terraform state before performing a destroy operation. Additionally, it adds a lifecycle ignore_changes policy to the Route53 A record to prevent Terraform from modifying it during normal operations.

## JIRA Ticket
[DPLAT-378](https://aplaceformom.atlassian.net/browse/DPLAT-378)

## Context
This feature supports the migration scenario outlined in the [Migrating ECS Services from Legacy terraform-ecs-app-action to Self-Service Fargate](https://aplaceformom.atlassian.net/wiki/spaces/DPLAT/pages/3753050114/Migrating+ECS+Services+from+Legacy+apfm-actions+terraform-ecs-app-action+to+Self-Service+Fargate) documentation.

During migration, we need to preserve the Route53 A record while destroying other infrastructure managed by this action. This option enables that workflow by removing the A record from Terraform state before the destroy operation runs.

## Changes
- Added `remove_r53_record_from_state` input to `action.yaml` with default value of `false`
- Added `lifecycle { ignore_changes = all }` to the Route53 A record resource to prevent unintended modifications

## Testing
- [ ] Tested with `remove_r53_record_from_state: false` (default behavior)
- [ ] Tested with `remove_r53_record_from_state: true` to verify A record is removed from state
- [ ] Verified destroy operation completes successfully with option enabled
- [ ] Verified lifecycle ignore_changes prevents modifications to existing A records