### PR TITLE
feat: migrate Docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/build-ghcr.yml
+++ b/.github/workflows/build-ghcr.yml
@@ -1,0 +1,35 @@
+name: Build and Push to GitHub Container Registry
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM apfm/terraform-action-base
+FROM ghcr.io/apfm-actions/terraform-action-base:latest
 WORKDIR /app
 COPY *.tf /app/


### PR DESCRIPTION
## Summary
- Migrate Docker image from Docker Hub to GitHub Container Registry (GHCR)
- Update Dockerfile to use GHCR-hosted base image
- Simplifies deployment by removing dependency on external Docker Hub credentials

## Context
This PR addresses the issue of outdated Docker images and lack of automated builds. While this repository (terraform-ecs-app-action) has Docker Hub deployment configured, the base image repository (terraform-action-base) doesn't have this setup, making it difficult to maintain consistent updates.

### Problem
- The base Docker image (`apfm/terraform-action-base`) on Docker Hub is outdated (last updated 2022)
- Limited access to Docker Hub credentials prevents timely updates
- No automated CI/CD pipeline for the base image

### Solution
- Switch to GitHub Container Registry for both base and application images
- Update Dockerfile to reference GHCR-hosted base image
- Leverage GitHub's built-in authentication and permissions

### Benefits
- Consistent image management across both repositories
- No external credentials required
- Automated builds through GitHub Actions
- Better visibility and version control

## Related Changes
- terraform-action-base: https://github.com/apfm-actions/terraform-action-base/pull/8 (adds GHCR build workflow)